### PR TITLE
Fix swapped belt tiers for loaders

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -43,8 +43,8 @@ elseif mods["deadlock-integrations"] then
 	DCM.LOADER_TWO = "fast-transport-belt-beltbox"
 	DCM.LOADER_THREE = "express-transport-belt-beltbox"
 	if data.raw.item["ultimate-transport-belt-beltbox"] then
-		DCM.LOADER_FOUR = "ultimate-transport-belt-beltbox"
-		DCM.LOADER_FIVE = "turbo-transport-belt-beltbox"
+		DCM.LOADER_FOUR = "turbo-transport-belt-beltbox"
+		DCM.LOADER_FIVE = "ultimate-transport-belt-beltbox"
 	else
 		DCM.LOADER_FOUR = "express-transport-belt"
 		DCM.LOADER_FIVE = "express-transport-belt"
@@ -54,8 +54,8 @@ else
 	DCM.LOADER_TWO = "fast-transport-belt"
 	DCM.LOADER_THREE = "express-transport-belt"
 	if data.raw.item["ultimate-transport-belt"] then
-		DCM.LOADER_FOUR = "ultimate-transport-belt"
-		DCM.LOADER_FIVE = "turbo-transport-belt"
+		DCM.LOADER_FOUR = "turbo-transport-belt"
+		DCM.LOADER_FIVE = "ultimate-transport-belt"
 	else
 		DCM.LOADER_FOUR = "express-transport-belt"
 		DCM.LOADER_FIVE = "express-transport-belt"


### PR DESCRIPTION
Tier 4 is "turbo" and tier 5 is "ultimate".
This changes the loaders to use the correct tiered items in their recipes.